### PR TITLE
✨ Add:人口カテゴリーで表示切り替え

### DIFF
--- a/api/population.ts
+++ b/api/population.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import axios from 'axios'
-import { apiResponse, PopulationData, PopulationLabel } from '../src/types/index'
+import { apiResponse, PopulationData } from '../src/types/index'
 
 
 const API_URL = 'https://opendata.resas-portal.go.jp/api/v1/'

--- a/src/components/PopulationChart.tsx
+++ b/src/components/PopulationChart.tsx
@@ -6,19 +6,22 @@ import { PopulationData } from '../types/index';
 
 type PopulationChartProps = {
     selectedPrefectures: { prefCode: number; prefName: string }[];
-  };
-  
-  const PopulationChart: React.FC<PopulationChartProps> = ({ selectedPrefectures }) => {
+    };
+
+    const PopulationChart: React.FC<PopulationChartProps> = ({ selectedPrefectures }) => {
     const [chartData, setChartData] = useState<any[]>([]);
     const [years, setYears] = useState<number[]>([]);
-  
+    const [selectedCategory, setSelectedCategory] = useState<string>('総人口');
+
     useEffect(() => {
         const fetchPopulationData = async () => {
         const promises = selectedPrefectures.map(async (pref) => {
             try {
                     // 都道府県の人口データを取得
                     const response = await axios.get(`/api/population?prefCode=${pref.prefCode}&cityCode=-`);
-                    const data = response.data.result.data[0].data; // 総人口データを取得
+                    const data = response.data.result.data.find(
+                        (categoryData: { label: string }) => categoryData.label === selectedCategory
+                    )?.data;
 
                     // データが持っている年を取得
                     const yearsFromData = data.map((item: PopulationData) => item.year);
@@ -45,7 +48,7 @@ type PopulationChartProps = {
         if (selectedPrefectures.length > 0) {
         fetchPopulationData();
         }
-    }, [selectedPrefectures]);
+    }, [selectedPrefectures, selectedCategory]);
 
     const chartOptions: Highcharts.Options = {
         title: {
@@ -64,9 +67,22 @@ type PopulationChartProps = {
             data: series.data,
         })),
     };
-  
+
     return (
         <div>
+            <div className="mb-4">
+                <label className="mr-4">人口の種類：</label>
+                <select
+                value={selectedCategory}
+                onChange={(e) => setSelectedCategory(e.target.value)}
+                className="p-2 border rounded"
+                >
+                    <option value="総人口">総人口</option>
+                    <option value="年少人口">年少人口</option>
+                    <option value="生産年齢人口">生産年齢人口</option>
+                    <option value="老年人口">老年人口</option>
+                </select>
+            </div>
             <HighchartsReact highcharts={Highcharts} options={chartOptions} />
         </div>
         );

--- a/src/components/PrefectureList.tsx
+++ b/src/components/PrefectureList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import { Prefectures } from '../types/index'; // 必要に応じて正しいパスに変更してください
+import { Prefectures } from '../types/index';
 
 type PrefectureListProps = {
   onSelectionChange: (selectedPrefCodesAndNames: { prefCode: number; prefName: string }[]) => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,8 +16,3 @@ export type PopulationData = {
     rate?: number
 }
 
-export type PopulationLabel = {
-    label: string
-    data: PopulationData[]
-}
-


### PR DESCRIPTION
## やったこと
- 人口カテゴリ（「総人口」、「年少人口」、「生産年齢人口」、「老年人口」）を切り替えて表示できるUIを追加しました。
- デフォルトでは「総人口」を選択して表示しますが、ユーザーが他のカテゴリを選択できるよう、ドロップダウンメニューを実装しました。

### 実装内容
1. PopulationChart.tsx コンポーネントにカテゴリ選択のためのドロップダウンメニューを追加。
- 「総人口」、「年少人口」、「生産年齢人口」、「老年人口」の4種類から選択可能。
- selectedCategory というステートを追加して、選択されたカテゴリに基づいて表示内容を動的に変更。
2. 選択されたカテゴリに応じた人口データをAPIから取得するロジックを実装。
- APIから取得したレスポンスの label と一致するデータを抽出し、グラフに表示。
3. デフォルト値として「総人口」を設定。
- 初期表示時には「総人口」が自動的に選択され、そのデータがグラフに表示されます。
